### PR TITLE
Add CMake build system support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# CMake
+build/
+build-*/
+out/
+CMakeCache.txt
+CMakeFiles/
+CMakeUserPresets.json
+cmake-build-*/
+
+# Visual Studio
+.vs/
+*.vcxproj.user
+x64/
+Win32/
+Debug/
+Release/
+
+# IDE
+.idea/
+.vscode/
+*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 3.16)
+project(GhostHunter LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+# Layout binaries the way the original project ships them, so the relative
+# resource paths baked into main.cpp ("../res/...") keep working.
+set(GH_RUNTIME_DIR ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GH_RUNTIME_DIR}/GhostHunter)
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+set(GH_COMMON_SOURCES
+    common/admin.cpp
+    common/camera.cpp
+    common/ghost.cpp
+    common/player.cpp
+    common/shaders.cpp
+    common/tools.cpp
+    common/model/mesh.cpp
+    common/model/model.cpp
+)
+
+set(GH_MAIN_SOURCES
+    GhostHunter/src/main.cpp
+    GhostHunter/src/glad.c
+)
+
+add_executable(GhostHunter ${GH_MAIN_SOURCES} ${GH_COMMON_SOURCES})
+
+target_include_directories(GhostHunter PRIVATE
+    ${CMAKE_SOURCE_DIR}/include       # GLFW, glad, KHR, glm, assimp, stb_image
+    ${CMAKE_SOURCE_DIR}/common        # tools.h, player.h, ...
+    ${CMAKE_SOURCE_DIR}/common/model  # model.h, mesh.h
+)
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+# OpenGL is provided by the platform.
+find_package(OpenGL REQUIRED)
+target_link_libraries(GhostHunter PRIVATE OpenGL::GL)
+
+# Threads — used by Ghost animation threads, Camera::timer, etc.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(GhostHunter PRIVATE Threads::Threads)
+
+if(WIN32)
+    # On Windows, use the vendored binaries that already ship in the repo,
+    # matching what GhostHunter.vcxproj + config/*.props do.
+    set(GH_VENDOR_LIB_DIR ${CMAKE_SOURCE_DIR}/lib)
+
+    target_link_libraries(GhostHunter PRIVATE
+        ${GH_VENDOR_LIB_DIR}/glfw3.lib
+        ${GH_VENDOR_LIB_DIR}/assimp-vc143-mt.lib
+    )
+    target_link_libraries(GhostHunter PRIVATE user32 gdi32 shell32)
+
+    # Copy the assimp runtime next to the exe so it can be launched directly.
+    add_custom_command(TARGET GhostHunter POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${GH_VENDOR_LIB_DIR}/assimp-vc143-mt.dll
+            $<TARGET_FILE_DIR:GhostHunter>
+    )
+
+    # Visual Studio: set the debugger CWD so "../res/..." resolves.
+    set_target_properties(GhostHunter PROPERTIES
+        VS_DEBUGGER_WORKING_DIRECTORY $<TARGET_FILE_DIR:GhostHunter>
+    )
+else()
+    # On Linux/macOS, assume system-installed dependencies.
+    find_package(glfw3 REQUIRED)
+    find_package(assimp REQUIRED)
+    target_link_libraries(GhostHunter PRIVATE glfw assimp::assimp ${CMAKE_DL_LIBS})
+endif()
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+# main.cpp loads shaders/models via "../res/..." relative to the working
+# directory. Mirror the original Excutable/ layout so the exe in
+# build/bin/GhostHunter/ can find build/bin/res/ at runtime.
+add_custom_command(TARGET GhostHunter POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/res
+        ${GH_RUNTIME_DIR}/res
+)

--- a/GhostHunter/src/main.cpp
+++ b/GhostHunter/src/main.cpp
@@ -12,7 +12,7 @@
 #endif // !STB_IMAGE_IMPLEMENTATION
 
 #include <fstream>
-#include <world.h>
+#include <World.h>
 #include <ghost.h>
 #include <random>
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,29 @@ Ghost Hunter is a simple FPS game project developed by C++ and OpenGL . Players 
 
 ## How to build&run
 
-- build: Just build in **visual studio 2022** in Windows **x86** architecture.
-- run directly:  run `./Excutable/GhostHunter/GhostHunter.exe`
+### Prebuilt (Windows)
+
+Run `./Excutable/GhostHunter/GhostHunter.exe`.
+
+### Visual Studio 2022 (Windows)
+
+Open `GhostHunter.sln` and build.
+
+### CMake
+
+```sh
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+The executable lands in `build/bin/GhostHunter/` and resources are staged
+under `build/bin/res/` so the exe can be launched directly.
+
+- **Windows**: uses the vendored `include/` and `lib/` shipped in the repo;
+  no external dependencies required.
+- **Linux / macOS**: install `glfw` and `assimp` via your package manager
+  (e.g. `apt install libglfw3-dev libassimp-dev`, `brew install glfw assimp`)
+  before configuring.
 
 ## Pictures
 


### PR DESCRIPTION
## Summary
This PR adds CMake build system support to the GhostHunter project, enabling cross-platform builds alongside the existing Visual Studio solution. The implementation maintains compatibility with the original project structure and resource paths.

## Key Changes
- **CMakeLists.txt**: New build configuration that:
  - Targets C++17 standard
  - Organizes binaries in `build/bin/GhostHunter/` with resources mirrored to `build/bin/res/`
  - Handles platform-specific dependencies (Windows vendored libs vs. Linux/macOS system packages)
  - Automatically copies required runtime files (assimp DLL on Windows)
  - Configures Visual Studio debugger working directory for relative resource paths

- **README.md**: Updated build instructions with:
  - Separate sections for prebuilt, Visual Studio, and CMake workflows
  - Platform-specific dependency information
  - Clear instructions for Linux/macOS users to install `glfw` and `assimp`

- **.gitignore**: New file covering:
  - CMake build artifacts (`build/`, `CMakeCache.txt`, etc.)
  - Visual Studio generated files (`.vs/`, `*.vcxproj.user`)
  - IDE configuration directories (`.idea/`, `.vscode/`)

## Notable Implementation Details
- The executable layout (`build/bin/GhostHunter/`) preserves the relative `../res/...` paths baked into `main.cpp`
- Windows builds use vendored libraries from `lib/` and `include/` directories already in the repo
- Linux/macOS builds assume system-installed dependencies via package managers
- Post-build steps handle resource directory copying and DLL staging automatically

https://claude.ai/code/session_01CMKdyTdGeKLkYJKHJqDivc