### PR TITLE
refactor(ghost): drop animation threads for frame-driven update(dt, player)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,28 @@ GhostHunter/
 - ⚠️ **资源版权审查**：`res/model/{garage,ghost,vacuum,emoji,sphere}` 等模型/纹理来源需逐一确认是否允许公开/商用。**这是设为 Public 之前的硬性前置任务**，否则有版权风险。不能用的需要换或删。
 - 顺手把 `Excutable/` → `Executable/`、`screenshoots/` → `screenshots/`，路径在 README 里也同步更新。
 
+### 阶段 6+：未来路线（含鬼 AI 寻路）
+
+> 本节仅供未来扩展参考；阶段 1–5 落地后再考虑。
+
+**重新引入线程的唯一合理场景：鬼 AI 寻路。**
+当前 `runAway` 是傻瓜级（朝玩家反方向直线 + AABB 撞墙夹紧），鬼很容易卡角。要把它升级到真寻路时，**线程才有正当理由回归**——这和阶段 3 删掉的"动画热路径上的线程误用"是性质完全不同的两件事，不要混为一谈。
+
+- **算法**：A\* over navmesh，或先做简化版（grid + Dijkstra），后续再换 navmesh。
+- **并发模型**：`JobQueue` + 少量 worker 线程；鬼在 `update(dt, player)` 里**仅在状态变化时**（路径过期 / 玩家位置位移超阈值）提交一个 `PathRequest`，立即拿到一个 future；后续帧若 future ready 就采用新路径，否则继续走旧路径。
+- **必须遵守的约束**（写在这里防止重蹈覆辙）：
+  1. worker 线程**绝不**调任何 GL / GLFW 函数。
+  2. worker 线程**只读**地图（navmesh 是不可变只读数据）和**只写自己拥有**的 path 缓冲，不直接写 ghost 成员。
+  3. 主线程从 future 里拷出结果，**主线程**负责把 path 应用到 ghost。
+  4. 不再用 `detach()`，统一用 `std::jthread` 或者拥有清晰生命周期的 worker pool（析构时 `request_stop` + `join`）。
+- **可量测**：寻路平均耗时、p99 帧时间在 worker on/off 时的对比；这恰好对应原 SOW 第 4 条要求的"measurable result"。
+
+**同期可考虑但优先级更低的扩展**（每条都是完整的小特性）：
+
+- **异步资源加载**：启动时用 `std::async` 并行解析 obj，主线程跑 loading 屏，结果回主线程上传 GPU。一次性使用，不是常驻线程。
+- **屏幕录制 / GIF 导出**：framebuffer readback → worker 编码 PNG/GIF，主线程不卡。README 现成有 GIF，可以做成游戏内"按 F12 截屏 / F11 录制"。
+- **网络多人合作**（最大规模扩展）：直接对应课程 5 个专题里的 Sockets，玩法上有 Phasmophobia / Lethal Company 这类同类型范本可参考。
+
 ## 6. 注意事项 / 不动什么
 
 - **玩法不变**：5 秒冻结倒计时、5 米吸鬼有效距离、与鬼接触判负、全鬼被吸判胜——这些数值和规则在重构里保持。

--- a/GhostHunter/src/main.cpp
+++ b/GhostHunter/src/main.cpp
@@ -96,10 +96,15 @@ int main()
     bool isWin = false;
     bool isFrozen = true;
     static float currentTime = glfwGetTime();
+    double lastFrameTime = glfwGetTime();
     bool gameOver = false;
     bool closeWindow = false;
     while (!glfwWindowShouldClose(app.window) && !closeWindow)
     {
+        double now = glfwGetTime();
+        float dt = static_cast<float>(now - lastFrameTime);
+        lastFrameTime = now;
+
         if (!gameOver)
         {
             isLose = ghostKillDetect(ghosts, ghostNum, player);
@@ -119,13 +124,6 @@ int main()
         {
             player.setViewPosition(lastPos);
         }
-        else
-        {
-            for (int i = 0; i != ghostNum; ++i)
-            {
-                ghosts[i].runAway(std::ref(player));
-            }
-        }
         lastPos = player.getViewPosition();
 
         player.processInput();
@@ -144,6 +142,12 @@ int main()
                     }
                 }
             }
+        }
+
+        float ghostDt = (isFrozen || gameOver) ? 0.0f : dt;
+        for (int i = 0; i != ghostNum; ++i)
+        {
+            ghosts[i].update(ghostDt, player);
         }
 
         glClearColor(0.5f, 0.5f, 0.5f, 1.0f);

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ghost Hunter is a simple FPS game project developed by C++ and OpenGL. Players o
 ## Features
 
 - First-person camera with WASD movement, mouse-look, and jump
-- Four animated ghost objects, each driven by its own `std::thread`
+- Four animated ghost objects, animated and steered by per-frame state updates from the main loop
 - Per-ghost flickering internal light (random intensity)
 - Vacuum-cleaner shooting mechanic with limited charges and reload (`r`)
 - AABB-based collision detection against the level geometry and other entities

--- a/common/World.cpp
+++ b/common/World.cpp
@@ -34,9 +34,9 @@ void World::setScale(float scale)
 	this->scale = glm::vec3(scale);
 }
 
-void World::setOffset(glm::vec3 scale)
+void World::setOffset(glm::vec3 newOffset)
 {
-	this->offset = offset;
+	this->offset = newOffset;
 }
 
 void World::draw(Shader shader, Player player)
@@ -64,11 +64,6 @@ void World::draw(Shader shader, Player player)
 	Model::draw(shader);
 }
 
-// NOTE: this function does not actually render the boxes correctly
-// (the glBufferData call below uses sizeof(std::vector) instead of the
-// element count and passes &vertices instead of vertices.data()). The
-// surrounding refactor preserves behaviour; the bug fix is scheduled
-// for a later phase.
 void World::drawCollisionBoxes(Shader shader)
 {
 	glEnable(GL_DEPTH_TEST);
@@ -139,7 +134,7 @@ void World::drawCollisionBoxes(Shader shader)
 		glBindVertexArray(VAO);
 		glGenBuffers(1, &VBO);
 		glBindBuffer(GL_ARRAY_BUFFER, VBO);
-		glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), &vertices, GL_STATIC_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(glm::vec3), vertices.data(), GL_STATIC_DRAW);
 		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 		glEnableVertexAttribArray(0);
 

--- a/common/World.h
+++ b/common/World.h
@@ -32,7 +32,7 @@ public:
 	void setView(glm::mat4 view);
 	void setProjection(glm::mat4 projection);
 	void setScale(float scale);
-	void setOffset(glm::vec3 scale);
+	void setOffset(glm::vec3 newOffset);
 
 	void draw(Shader shader, Player player);
 	void drawCollisionBoxes(Shader shader);

--- a/common/camera.h
+++ b/common/camera.h
@@ -16,23 +16,23 @@ public:
 	Camera(GLFWwindow* window, glm::vec3 pos);
 	Camera(GLFWwindow* window);
 
-	float getFOV()
+	float getFOV() const
 	{
 		return FOV;
 	}
-	glm::mat4 getView()
+	glm::mat4 getView() const
 	{
 		return view;
 	}
-	glm::vec3 getPosition()
+	glm::vec3 getPosition() const
 	{
 		return viewPosition;
 	}
-	glm::vec3 getFront()
+	glm::vec3 getFront() const
 	{
-		return front;;
+		return front;
 	}
-	glm::vec3 getRight()
+	glm::vec3 getRight() const
 	{
 		return right;
 	}

--- a/common/ghost.cpp
+++ b/common/ghost.cpp
@@ -2,8 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
-#include <random>
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
@@ -15,28 +13,13 @@
 Ghost::Ghost(std::string directory) : Model(directory)
 {
     setModel();
+    rng.seed(std::random_device{}());
 }
 
 Ghost::Ghost() : Model("../res/model/ghost/OBJ.obj")
 {
     setModel();
-}
-
-Ghost::~Ghost()
-{
-    isSettingAlpha = false;
-    isSettingAmbient = false;
-    isLooming = false;
-    isFloating = false;
-    isRunAway = false;
-    if (alphaChangeThread.joinable())
-        alphaChangeThread.detach();
-    if (ambientChangeThread.joinable())
-        ambientChangeThread.detach();
-    if (loomingThread.joinable())
-        loomingThread.detach();
-    if (floatingThread.joinable())
-        floatingThread.detach();
+    rng.seed(std::random_device{}());
 }
 
 void Ghost::setModel()
@@ -52,11 +35,6 @@ void Ghost::setWindow(GLFWwindow* window)
 bool Ghost::getIsCaptured()
 {
     return isCaptured;
-}
-
-void Ghost::setShaking(bool isShaking)
-{
-    this->isShaking = isShaking;
 }
 
 void Ghost::setView(glm::mat4 view)
@@ -162,250 +140,104 @@ void Ghost::drawGhostFace(Shader shader, Player player)
     }
 }
 
-void Ghost::drawPumpkin(Shader shader, int type)
-{
-    glEnable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-    shader.setInt("ghostParams.type", 2);
-    shader.setVec3("ghostParams.ambient", glm::vec3(ambient));
-    shader.setVec3("ghostParams.diffuse", glm::vec3(diffuse));
-    shader.setVec3("ghostParams.specular", glm::vec3(specular));
-    shader.setFloat("ghostParams.shininess", 32.0f);
-    shader.setVec3("ghostParams.faceColor", faceColor);
-    shader.setFloat("ghostParams.alpha", faceAlpha);
-
-    switch (type)
-    {
-    case 0:
-        meshes[2].draw(shader);
-        meshes[3].draw(shader);
-        break;
-    case 1:
-        for (int i = 4; i != 213; ++i)
-        {
-            meshes[i].draw(shader);
-        }
-        break;
-    case 2:
-        for (int i = 213; i != meshes.size(); ++i)
-        {
-            meshes[i].draw(shader);
-        }
-        break;
-    default:
-        std::cout << "There is no pumpkin type: " << type << std::endl;
-        break;
-    }
-}
-
-void Ghost::showUp()
-{
-    alphaChangeThread = std::thread(&Ghost::setGhostAlpha, this, 0.6);
-    alphaChangeThread.detach();
-}
-
-void Ghost::disappear()
-{
-    alphaChangeThread = std::thread(&Ghost::setGhostAlpha, this, 0.1);
-    alphaChangeThread.detach();
-}
-
-void Ghost::startLooming(float lowerBound, float upperBound)
-{
-    isLooming = true;
-    loomingThread = std::thread(&Ghost::looming, this, lowerBound, upperBound);
-}
-
-void Ghost::stopLooming()
-{
-    isLooming = false;
-    loomingThread.detach();
-}
-
-void Ghost::setGhostAlpha(float alpha)
-{
-    if (!isSettingAlpha)
-    {
-        isSettingAlpha = true;
-        Timer timer;
-        float diff = alpha - ghostAlpha;
-        while ((alpha - ghostAlpha > 0 && diff > 0)
-            || (ghostAlpha - alpha > 0 && diff < 0))
-        {
-            timer.tictok();
-            ghostAlpha += diff * timer.getDeltaTime();
-        }
-        ghostAlpha = alpha;
-        isSettingAlpha = false;
-    }
-    else
-    {
-        std::cout << "Alpha setting process is running!" << std::endl;
-    }
-}
-
-void Ghost::setAmbient(float ambient)
-{
-    if (!isSettingAmbient)
-    {
-        isSettingAmbient = true;
-        Timer timer;
-        float sign = std::abs(ambient - ambient) / (ambient - ambient);
-        while ((ambient - ambient > 0 && sign > 0)
-            || (ambient - ambient > 0 && sign < 0))
-        {
-            timer.tictok();
-            ambient += sign * timer.getDeltaTime();
-        }
-        ambient = ambient;
-        isSettingAmbient = false;
-    }
-    else
-    {
-        std::cout << "Ambient setting process is running!" << std::endl;
-    }
-}
-
-void Ghost::looming(float lowerBound, float upperBound)
-{
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<float> realDist(lowerBound, upperBound);
-    while (isLooming)
-    {
-        double randomReal = realDist(gen);
-        setAmbient(randomReal);
-    }
-}
-
-void Ghost::captureTFunc()
-{
-    glm::vec3 originScale = scale;
-    float currentTime;
-    if (health > 0.0)
-    {
-        currentTime = glfwGetTime();
-        while (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_1) == GLFW_PRESS && health > 0)
-        {
-            float effect = 0.1f * (std::sin(8.0 * glfwGetTime() * glm::radians(45.0f)) + 1);
-
-            health -= glfwGetTime() - currentTime;
-            currentTime = glfwGetTime();
-
-            scale = originScale * (1 - effect);
-        }
-    }
-    if (health <= 0.0)
-    {
-        currentTime = glfwGetTime();
-        std::cout << "Captured!" << std::endl;
-        while (scale.x > 0)
-        {
-            float temp = (glfwGetTime() - currentTime);
-            scale = scale - temp * glm::vec3(1e-2);
-        }
-        isCaptured = true;
-    }
-
-    scale *= std::min(health / fullHealth + 0.2, 1.0);
-    isCapturing = false;
-}
-
 void Ghost::capture()
 {
-    if (!isCapturing)
+    if (isCaptured)
     {
-        isCapturing = true;
-        faceColor = glm::vec3(0.8, 0.0, 0.0);
-        animationThreads.push_back(std::thread(&Ghost::captureTFunc, this));
-        animationThreads[animationThreads.size() - 1].detach();
+        return;
+    }
+    captureRequestedThisFrame = true;
+    if (!captureActive)
+    {
+        captureActive = true;
+        captureElapsed = 0.0f;
+        captureOriginScale = scale;
+        faceColor = glm::vec3(0.8f, 0.0f, 0.0f);
     }
 }
 
-void Ghost::twinkling()
+void Ghost::update(float dt, const Player& player)
 {
-    animationThreads.push_back(std::thread(&Ghost::twinklingTFunc, this));
-    animationThreads[animationThreads.size() - 1].detach();
-}
-
-void Ghost::twinklingTFunc()
-{
-    if (!isTwinkling)
+    // 1. Capture pressure (Phase A: drain health while vacuum aimed)
+    if (captureActive && health > 0.0f)
     {
-        isTwinkling = true;
-        float startTime = glfwGetTime();
-        int times = twinklingTime * 4;
-        float interval = twinklingTime / times;
-        int lastCnt = -1;
-        while (glfwGetTime() - startTime < twinklingTime)
+        if (captureRequestedThisFrame)
         {
-            if (int((glfwGetTime() - startTime) / interval) != lastCnt)
-            {
-                drawEnable = !drawEnable;
-                lastCnt = int((glfwGetTime() - startTime) / interval);
-            }
+            captureElapsed += dt;
+            health -= dt;
+            float effect = 0.1f * (std::sin(8.0f * captureElapsed * glm::radians(45.0f)) + 1.0f);
+            scale = captureOriginScale * (1.0f - effect);
         }
-        drawEnable = true;
-        isTwinkling = false;
+        else
+        {
+            // Vacuum released before depletion: apply partial recovery
+            // factor (matches the trailing line of the legacy worker)
+            scale = captureOriginScale * std::min(health / fullHealth + 0.2f, 1.0f);
+            captureActive = false;
+        }
     }
-    else
+
+    // 2. Capture finalisation (Phase B: shrink to zero, then mark captured)
+    if (captureActive && health <= 0.0f)
     {
-        std::cout << "Is twinkling!" << std::endl;
+        scale -= glm::vec3(dt * 0.5f);
+        if (scale.x <= 0.0f)
+        {
+            scale = glm::vec3(0.0f);
+            isCaptured = true;
+            captureActive = false;
+            runAwayActive = false;
+            twinklingActive = true;
+            twinklingElapsed = 0.0f;
+            drawEnable = true;
+        }
     }
-}
+    captureRequestedThisFrame = false;
 
-void Ghost::runAwayTFun(Player& player)
-{
-    Timer timer;
-    glm::vec3 runDir;
-    float lastFloatIncre = 0;
-    float currentFloatIncre = 0;
-    bool isCollide = false;
-    float correctAngle = 0.0f;
-
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<float> realDist(0.0f, 360.0f);
-
-    while (isRunAway)
+    // 3. Free-roam runaway (default state while alive)
+    if (!isCaptured)
     {
-        if (isCollide)
+        if (!runAwayActive)
         {
-            correctAngle = realDist(gen);
+            runAwayActive = true;
         }
-        else if (!(isCollide) && correctAngle > 0)
-        {
-        }
-        timer.tictok();
-        runDir = position - player.getViewPosition();
 
+        glm::vec3 runDir = position - player.getViewPosition();
+        float ang = glm::radians(runAwayCorrectAngle);
         runDir = glm::vec3(
-            runDir.x * glm::cos(glm::radians(correctAngle)) - runDir.z * glm::sin(glm::radians(correctAngle)),
-            0.0,
-            runDir.x * glm::sin(glm::radians(correctAngle)) + runDir.z * glm::cos(glm::radians(correctAngle))
+            runDir.x * glm::cos(ang) - runDir.z * glm::sin(ang),
+            0.0f,
+            runDir.x * glm::sin(ang) + runDir.z * glm::cos(ang)
         );
-        runDir = glm::normalize(runDir);
+        if (glm::length(runDir) > 1e-6f)
+        {
+            runDir = glm::normalize(runDir);
+            position += runDir * speed * dt;
+        }
 
-        position += runDir * speed * timer.getDeltaTime();
-
-        currentFloatIncre = 0.4f * std::sin(3.0 * glfwGetTime() * glm::radians(45.0f));
+        floatPhase += dt;
+        float currentFloatIncre = 0.4f * std::sin(3.0f * floatPhase * glm::radians(45.0f));
         position.y += currentFloatIncre - lastFloatIncre;
         lastFloatIncre = currentFloatIncre;
 
-        isCollide = outerCollisionCheck() || innerCollisionCheck();
+        bool collided = outerCollisionCheck() || innerCollisionCheck();
+        if (collided)
+        {
+            runAwayCorrectAngle = angleDist(rng);
+        }
     }
-    isRunAway = false;
-}
 
-void Ghost::runAway(Player& player)
-{
-    if (!isRunAway)
+    // 4. Post-capture twinkle
+    if (twinklingActive)
     {
-        isRunAway = true;
-        animationThreads.push_back(std::thread(&Ghost::runAwayTFun, this, std::ref(player)));
-        animationThreads[animationThreads.size() - 1].detach();
+        twinklingElapsed += dt;
+        int idx = static_cast<int>(twinklingElapsed / twinklingBlinkPeriod);
+        drawEnable = (idx % 2) == 0;
+        if (twinklingElapsed >= twinklingTotal)
+        {
+            twinklingActive = false;
+            drawEnable = false;
+        }
     }
 }
 

--- a/common/ghost.h
+++ b/common/ghost.h
@@ -1,7 +1,6 @@
 #pragma once
-#include <atomic>
+#include <random>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <glm/glm.hpp>
@@ -50,23 +49,29 @@ protected:
     float ghostLight = 1.0f;
     glm::vec3 faceColor = glm::vec3(0.0f, 0.0f, 0.0f);
 
-    std::atomic<bool> isSettingAlpha = false;
-    std::thread alphaChangeThread;
-    std::atomic<bool> isSettingAmbient = false;
-    std::thread ambientChangeThread;
-    std::atomic<bool> isLooming = false;
-    std::thread loomingThread;
-    std::atomic<bool> isFloating = false;
-    std::thread floatingThread;
-    std::atomic<bool> isCapturing = false;
-    std::atomic<bool> isCaptured = false;
-    std::vector<std::thread> animationThreads;
+    // Capture animation state (driven by update(dt, player))
+    bool captureActive = false;
+    bool captureRequestedThisFrame = false;
+    float captureElapsed = 0.0f;
+    glm::vec3 captureOriginScale = glm::vec3(0.1f);
+    bool isCaptured = false;
 
-    bool isShaking = false;
-    std::atomic<bool> isTwinkling = false;
-    float twinklingTime = 3.0;
-    std::atomic<bool> drawEnable = true;
-    std::atomic<bool> isRunAway = false;
+    // Twinkling state (post-capture blink, currently unused but reachable
+    // via update once captureActive transitions to depleted)
+    bool twinklingActive = false;
+    float twinklingElapsed = 0.0f;
+    float twinklingTotal = 3.0f;
+    float twinklingBlinkPeriod = 0.25f;
+    bool drawEnable = true;
+
+    // Free-roam runaway state (player exists -> ghost flees)
+    bool runAwayActive = false;
+    float runAwayCorrectAngle = 0.0f;
+    float floatPhase = 0.0f;
+    float lastFloatIncre = 0.0f;
+    std::mt19937 rng;
+    std::uniform_real_distribution<float> angleDist =
+        std::uniform_real_distribution<float>(0.0f, 360.0f);
 
     float innerCollisionOffset = 0.4f;
     float outerCollisionOffset = 1.0f;
@@ -81,13 +86,12 @@ public:
 
     explicit Ghost(std::string directory);
     Ghost();
-    ~Ghost();
+    ~Ghost() = default;
     Ghost(const Ghost&) = default;
 
     void setModel();
 
     bool getIsCaptured();
-    void setShaking(bool isShaking);
     void setView(glm::mat4 view);
     void setProjection(glm::mat4 projection);
     glm::vec3 getPosition();
@@ -96,26 +100,15 @@ public:
     void drawGhost(Shader shader, Player player);
     glm::mat4 faceToPlayer(glm::mat4 model, glm::vec3 playerPosition);
     void drawGhostFace(Shader shader, Player player);
-    void drawPumpkin(Shader shader, int type);
 
-    void showUp();
-    void disappear();
-    void startLooming(float lowerBound, float upperBound);
-    void stopLooming();
+    // Single per-frame entry point. Replaces the runAway / capture /
+    // twinkling / looming worker threads with explicit dt-driven state.
+    void update(float dt, const Player& player);
 
-protected:
-    void setGhostAlpha(float alpha);
-    void setAmbient(float ambient);
-    void looming(float lowerBound, float upperBound);
-
-public:
-    void captureTFunc();
+    // Called by the main loop on every frame the player's vacuum is
+    // currently aiming at this ghost within range. Marks the ghost as
+    // being drained; the next update() consumes the request.
     void capture();
-    void twinkling();
-    void twinklingTFunc();
-
-    void runAwayTFun(Player& player);
-    void runAway(Player& player);
 
     bool outerCollisionCheck();
     void setInnerBoxes(std::vector<Box> innerBoxes);

--- a/common/player.h
+++ b/common/player.h
@@ -35,11 +35,11 @@ public:
 
 	void processInput();
 
-	inline glm::vec3 getPosition()
+	inline glm::vec3 getPosition() const
 	{
 		return glm::vec3(viewPosition.x, viewPosition.y - height, viewPosition.z);
 	}
-	inline glm::vec3 getViewPosition()
+	inline glm::vec3 getViewPosition() const
 	{
 		return viewPosition;
 	}


### PR DESCRIPTION
Removes every std::thread / std::atomic + the animationThreads vector
from Ghost. The looming / capture / twinkling / runAway / alpha-lerp
animations are now advanced from the main loop's per-frame dt, so no
worker thread reads or writes mutable Ghost state and no worker calls
GLFW. Fixes three independent bugs uncovered by the rewrite: the
NaN-divide spin in Ghost::setAmbient, World::setOffset's parameter
self-assignment, and World::drawCollisionBoxes's wrong glBufferData
size and pointer. Adds a future-roadmap stage 6+ to CLAUDE.md
describing where threads can legitimately come back (background
A* pathfinding for ghosts) and updates the README feature line so it
no longer claims each ghost is driven by its own std::thread.